### PR TITLE
Modify minimap2 commands for plasmid and GCF filtering

### DIFF
--- a/qp_pacbio/data/templates/syndna.sbatch
+++ b/qp_pacbio/data/templates/syndna.sbatch
@@ -53,7 +53,7 @@ biom convert -i ${tsv} -o ${sn_folder}/syndna.biom --to-hdf5
 # samtools view -F 4 -@ {{nprocs}} ${out_folder}/${sample_name}_plasmid.sam | awk '{print $1}' | sort -u > ${out_folder}/${sample_name}_plasmid_mapped.txt
 # seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${out_folder}/${sample_name}_no_plasmid.fastq
 # ---- original commands ----
-minimap2 -x map-hifi -t {{nprocs}} -a --MD --eqx -o ${out_folder}/${sample_name}_plasmid.sam ${db_folder}/AllsynDNA_plasmids_FASTA_ReIndexed_FINAL.fasta $filename
+minimap2 -x map-hifi -t {{nprocs}} -a --MD --eqx --secondary=no -o ${out_folder}/${sample_name}_plasmid.sam ${db_folder}/AllsynDNA_plasmids_FASTA_ReIndexed_FINAL.fasta $filename
 samtools view -F 4 -@ {{nprocs}} ${out_folder}/${sample_name}_plasmid.sam | awk '{print $1}' | sort -u > ${out_folder}/${sample_name}_plasmid_mapped.txt
 seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${out_folder}/${sample_name}_no_plasmid.fastq
 
@@ -66,7 +66,7 @@ seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${
 # awk '{print $1}' reads_filtered.sam > reads_filtered.txt
 # seqkit grep -v -f reads_filtered.txt reads.fastq > reads_no_ecoli.fastq
 # ---- original commands ----
-minimap2 -x map-hifi -t {{nprocs}} -a --MD --eqx -o ${out_folder}/${sample_name}_GCF_000184185.sam ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq
+minimap2 -x map-hifi -t {{nprocs}} -a --MD --eqx --secondary=no ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq | samtools view -h -F 0x800 -  > ${out_folder}/${sample_name}_GCF_000184185.sam
 samtools view -bS -@ {{ nprocs/2 | int }} ${out_folder}/${sample_name}_GCF_000184185.sam | samtools sort -@ {{ nprocs/2 | int }} -O bam -o ${out_folder}/${sample_name}_GCF_000184185_sorted.bam
 coverm filter --bam-files ${out_folder}/${sample_name}_GCF_000184185_sorted.bam --min-read-percent-identity 99.9 --min-read-aligned-percent 95 --threads {{nprocs}} -o ${out_folder}/${sample_name}_GCF_000184185.bam
 samtools view -O SAM -o ${out_folder}/${sample_name}_no_GCF_000184185_sorted.sam ${out_folder}/${sample_name}_GCF_000184185.bam

--- a/qp_pacbio/data/templates/syndna.sbatch
+++ b/qp_pacbio/data/templates/syndna.sbatch
@@ -66,7 +66,7 @@ seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${
 # awk '{print $1}' reads_filtered.sam > reads_filtered.txt
 # seqkit grep -v -f reads_filtered.txt reads.fastq > reads_no_ecoli.fastq
 # ---- original commands ----
-minimap2 -x map-hifi -t {{nprocs}} -a --MD --eqx --secondary=no ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq | samtools view -h -F 0x800 -  > ${out_folder}/${sample_name}_GCF_000184185.sam
+minimap2 -x map-hifi -t {{nprocs}} -a --MD --eqx --secondary=no ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq | samtools view -h -F 0x800 - > ${out_folder}/${sample_name}_GCF_000184185.sam
 samtools view -bS -@ {{ nprocs/2 | int }} ${out_folder}/${sample_name}_GCF_000184185.sam | samtools sort -@ {{ nprocs/2 | int }} -O bam -o ${out_folder}/${sample_name}_GCF_000184185_sorted.bam
 coverm filter --bam-files ${out_folder}/${sample_name}_GCF_000184185_sorted.bam --min-read-percent-identity 99.9 --min-read-aligned-percent 95 --threads {{nprocs}} -o ${out_folder}/${sample_name}_GCF_000184185.bam
 samtools view -O SAM -o ${out_folder}/${sample_name}_no_GCF_000184185_sorted.sam ${out_folder}/${sample_name}_GCF_000184185.bam

--- a/qp_pacbio/tests/test_pacbio.py
+++ b/qp_pacbio/tests/test_pacbio.py
@@ -385,7 +385,7 @@ class PacWoltkaSynDNATests(PacBioTests):
             "\n",
             "biom convert -i ${tsv} -o ${sn_folder}/syndna.biom --to-hdf5\n",
             "\n",
-            "minimap2 -x map-hifi -t 16 -a --MD --eqx -o ${out_folder}/${sample_name}_plasmid.sam ${db_folder}/AllsynDNA_plasmids_FASTA_ReIndexed_FINAL.fasta $filename\n",
+            "minimap2 -x map-hifi -t 16 -a --MD --eqx --secondary=no -o ${out_folder}/${sample_name}_plasmid.sam ${db_folder}/AllsynDNA_plasmids_FASTA_ReIndexed_FINAL.fasta $filename\n",
             "samtools view -F 4 -@ 16 ${out_folder}/${sample_name}_plasmid.sam | awk '{print $1}' | sort -u > ${out_folder}/${sample_name}_plasmid_mapped.txt\n",
             "seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${out_folder}/${sample_name}_no_plasmid.fastq\n",
             "\n",

--- a/qp_pacbio/tests/test_pacbio.py
+++ b/qp_pacbio/tests/test_pacbio.py
@@ -389,7 +389,7 @@ class PacWoltkaSynDNATests(PacBioTests):
             "samtools view -F 4 -@ 16 ${out_folder}/${sample_name}_plasmid.sam | awk '{print $1}' | sort -u > ${out_folder}/${sample_name}_plasmid_mapped.txt\n",
             "seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${out_folder}/${sample_name}_no_plasmid.fastq\n",
             "\n",
-            "minimap2 -x map-hifi -t 16 -a --MD --eqx -o ${out_folder}/${sample_name}_GCF_000184185.sam ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq\n",
+            "minimap2 -x map-hifi -t 16 -a --MD --eqx --secondary=no ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq | samtools view -h -F 0x800 - ${out_folder}/${sample_name}_GCF_000184185.sam\n",
             "samtools view -bS -@ 8.0 ${out_folder}/${sample_name}_GCF_000184185.sam | samtools sort -@ 8.0 -O bam -o ${out_folder}/${sample_name}_GCF_000184185_sorted.bam\n",
             "coverm filter --bam-files ${out_folder}/${sample_name}_GCF_000184185_sorted.bam --min-read-percent-identity 99.9 --min-read-aligned-percent 95 --threads 16 -o ${out_folder}/${sample_name}_GCF_000184185.bam\n",
             "samtools view -O SAM -o ${out_folder}/${sample_name}_no_GCF_000184185_sorted.sam ${out_folder}/${sample_name}_GCF_000184185.bam\n",

--- a/qp_pacbio/tests/test_pacbio.py
+++ b/qp_pacbio/tests/test_pacbio.py
@@ -389,7 +389,7 @@ class PacWoltkaSynDNATests(PacBioTests):
             "samtools view -F 4 -@ 16 ${out_folder}/${sample_name}_plasmid.sam | awk '{print $1}' | sort -u > ${out_folder}/${sample_name}_plasmid_mapped.txt\n",
             "seqkit grep -v -f ${out_folder}/${sample_name}_plasmid_mapped.txt $filename > ${out_folder}/${sample_name}_no_plasmid.fastq\n",
             "\n",
-            "minimap2 -x map-hifi -t 16 -a --MD --eqx --secondary=no ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq | samtools view -h -F 0x800 - ${out_folder}/${sample_name}_GCF_000184185.sam\n",
+            "minimap2 -x map-hifi -t 16 -a --MD --eqx --secondary=no ${db_folder}/GCF_000184185.1_ASM18418v1_genomic_chroso.fna ${out_folder}/${sample_name}_no_plasmid.fastq | samtools view -h -F 0x800 - > ${out_folder}/${sample_name}_GCF_000184185.sam\n",
             "samtools view -bS -@ 8.0 ${out_folder}/${sample_name}_GCF_000184185.sam | samtools sort -@ 8.0 -O bam -o ${out_folder}/${sample_name}_GCF_000184185_sorted.bam\n",
             "coverm filter --bam-files ${out_folder}/${sample_name}_GCF_000184185_sorted.bam --min-read-percent-identity 99.9 --min-read-aligned-percent 95 --threads 16 -o ${out_folder}/${sample_name}_GCF_000184185.bam\n",
             "samtools view -O SAM -o ${out_folder}/${sample_name}_no_GCF_000184185_sorted.sam ${out_folder}/${sample_name}_GCF_000184185.bam\n",


### PR DESCRIPTION
Updated minimap2 commands to include '--secondary=no' and adjusted output handling for GCF genomic data. All secondary and supplementary are not considered for mapping to any reference, including SynDNA and E. coli. It should only matter for E coli filtering as there are many E coli reads in the sample that are multi-mapping. 